### PR TITLE
Fix state mutation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fp:
 
 setup(
     name="discrete-event-simulation",
-    version="0.1.1",
+    version="0.1.2",
     description="Framework for making discrete event simulations",
     long_description=long_description,
     author="Alexander Grooff",

--- a/simulation/framework.py
+++ b/simulation/framework.py
@@ -296,7 +296,7 @@ class DiscreteSimulation:
                 )
                 break
             logger.debug("Executing event {} at time {}".format(event, new_time))
-            new_state = event(state=self.timeline.current_state)
+            new_state = deepcopy(event(state=self.timeline.current_state))
 
             # Apply new state
             self.timeline.set_state(state=new_state, time=new_time)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -106,3 +106,9 @@ class TestSimulationFramework(TestCase):
         self.sim.reset(initial_values={"water": 5000})
         self.sim.run()
         self.assertDictEqual(self.sim.timeline.current_state.values, {"water": 5002})
+
+    def test_state_changes_over_time(self):
+        self.sim.run()
+        first_state = self.sim.timeline.states[0]
+        second_state = self.sim.timeline.states[3]
+        self.assertNotEqual(first_state.values, second_state.values)


### PR DESCRIPTION
Previous states were changed because a new state wasn't copied, but just used the old state instead. This mutated the timeline after the time has already passed. 